### PR TITLE
Use versioned contracts in partials default paths

### DIFF
--- a/lib/partials.js
+++ b/lib/partials.js
@@ -71,9 +71,13 @@ exports.findPartial = (name, context, options) => {
     })
     .thru((combinations) => {
       const fallbackPaths = _.chain(combinations)
-        .map(_.last)
         .reduce((accumulator, value, index, collection) => {
-          return [ _.take(collection, index + 1) ].concat(accumulator)
+          return _.map([
+            _.map(collection, _.first),
+            _.map(collection, _.last)
+          ], (list) => {
+            return _.take(list, index + 1)
+          }).concat(accumulator)
         }, [])
         .value()
 

--- a/test/partials/find-partial.spec.js
+++ b/test/partials/find-partial.spec.js
@@ -245,6 +245,7 @@ ava.test('should find a partial in a two level structure with one contract of ea
     'path/to/partials/raspberrypi3@rev1+armv7hf/my-partial.tpl',
     'path/to/partials/raspberrypi3+armv7hf@1/my-partial.tpl',
     'path/to/partials/raspberrypi3+armv7hf/my-partial.tpl',
+    'path/to/partials/raspberrypi3@rev1/my-partial.tpl',
     'path/to/partials/raspberrypi3/my-partial.tpl',
     'path/to/partials/my-partial.tpl'
   ])


### PR DESCRIPTION
Fixes: https://github.com/resin-io-playground/base-img-generator/issues/2
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>