### PR TITLE
Use bigCombination instead of Combination to handle larger array.

### DIFF
--- a/lib/contract.js
+++ b/lib/contract.js
@@ -823,7 +823,7 @@ class Contract {
 
     const range = _.range(options.from, Math.min(options.to, contracts.length) + 1)
     return _.flatMap(range, (cardinality) => {
-      return combinatorics.combination(contracts, cardinality).toArray()
+      return combinatorics.bigCombination(contracts, cardinality).toArray()
     })
   }
 


### PR DESCRIPTION
Fixes https://github.com/resin-io-playground/base-img-generator/issues/6.

Since Combinatorics.combination only supports array length up to 31 so we can't add more than 31 contracts (https://github.com/dankogai/js-combinatorics#combinatoricscombination-ary--nelem-)